### PR TITLE
Task 3, add machine type e2-standard-2

### DIFF
--- a/Cloud Monitoring: Qwik Start/abhishekGSP089.sh
+++ b/Cloud Monitoring: Qwik Start/abhishekGSP089.sh
@@ -76,12 +76,21 @@ sleep 10
 echo "${GREEN_TEXT}${BOLD_TEXT}Fetching Instance ID...${RESET_FORMAT}"
 
 INSTANCE_ID="$(gcloud compute instances describe lamp-1-vm --project=$DEVSHELL_PROJECT_ID --zone=$ZONE --format='value(id)')"
-
+EXTERNAL_IP="$(gcloud compute instances describe lamp-1-vm --zone=$ZONE --format="get(networkInterfaces[0].accessConfigs[0].natIP)")"
+  
 echo "${BLUE_TEXT}${BOLD_TEXT}Setting up Uptime Monitoring...${RESET_FORMAT}"
 
-gcloud monitoring uptime create lamp-uptime-check \
-  --resource-type="gce-instance" \
-  --resource-labels=project_id=$DEVSHELL_PROJECT_ID,instance_id=$INSTANCE_ID,zone=$ZONE
+# gcloud monitoring uptime create lamp-uptime-check \
+#   --resource-type="gce-instance" \
+#   --resource-labels=project_id=$DEVSHELL_PROJECT_ID,instance_id=$INSTANCE_ID,zone=$ZONE
+gcloud monitoring uptime create "Lamp Uptime Check" \
+  --resource-type="uptime-url" \
+  --resource-labels=host="$EXTERNAL_IP" \
+  --path="/" \
+  --protocol="http" \
+  --port=80 \
+  --period=1 \
+  --timeout=10
 
 echo "${YELLOW_TEXT}${BOLD_TEXT}Creating an email notification channel...${RESET_FORMAT}"
 

--- a/Cloud Monitoring: Qwik Start/abhishekGSP089.sh
+++ b/Cloud Monitoring: Qwik Start/abhishekGSP089.sh
@@ -76,6 +76,9 @@ sleep 10
 echo "${GREEN_TEXT}${BOLD_TEXT}Fetching Instance ID...${RESET_FORMAT}"
 
 INSTANCE_ID="$(gcloud compute instances describe lamp-1-vm --project=$DEVSHELL_PROJECT_ID --zone=$ZONE --format='value(id)')"
+
+echo "${GREEN_TEXT}${BOLD_TEXT}Fetching External IP...${RESET_FORMAT}"
+
 EXTERNAL_IP="$(gcloud compute instances describe lamp-1-vm --zone=$ZONE --format="get(networkInterfaces[0].accessConfigs[0].natIP)")"
   
 echo "${BLUE_TEXT}${BOLD_TEXT}Setting up Uptime Monitoring...${RESET_FORMAT}"

--- a/Develop your Google Cloud Network: Challenge Lab/abhishek.sh
+++ b/Develop your Google Cloud Network: Challenge Lab/abhishek.sh
@@ -33,6 +33,7 @@ BLUE=`tput setaf 4`
 MAGENTA=`tput setaf 5`
 CYAN=`tput setaf 6`
 WHITE=`tput setaf 7`
+NC='\033[0m' # No Color
 
 BG_BLACK=`tput setab 0`
 BG_RED=`tput setab 1`
@@ -46,6 +47,9 @@ BG_WHITE=`tput setab 7`
 BOLD=`tput bold`
 RESET=`tput sgr0`
 #----------------------------------------------------start--------------------------------------------------#
+
+read -p "$(echo -e "${BLUE}ENTER ZONE (e.g., us-central1-a): ${NC}")" ZONE
+echo ""
 
 echo "${YELLOW}${BOLD}Starting${RESET}" "${GREEN}${BOLD}Execution${RESET}"
 
@@ -72,8 +76,14 @@ cd ..
 
 echo "${RED}${BOLD}Task 2. ${RESET}""${WHITE}${BOLD}Create production VPC manually${RESET}" "${GREEN}${BOLD}Completed${RESET}"
 
-gcloud compute instances create bastion --network-interface=network=griffin-dev-vpc,subnet=griffin-dev-mgmt  --network-interface=network=griffin-prod-vpc,subnet=griffin-prod-mgmt --tags=ssh --zone=$ZONE
-
+# gcloud compute instances create bastion --network-interface=network=griffin-dev-vpc,subnet=griffin-dev-mgmt  --network-interface=network=griffin-prod-vpc,subnet=griffin-prod-mgmt --tags=ssh --zone=$ZONE
+gcloud compute instances create bastion \
+  --zone=$ZONE \
+  --machine-type=e2-medium \
+  --network-interface=subnet=griffin-dev-mgmt,network=griffin-dev-vpc \
+  --network-interface=subnet=griffin-prod-mgmt,network=griffin-prod-vpc \
+  --tags=ssh
+  
 gcloud compute firewall-rules create fw-ssh-dev --source-ranges=0.0.0.0/0 --target-tags ssh --allow=tcp:22 --network=griffin-dev-vpc
 
 gcloud compute firewall-rules create fw-ssh-prod --source-ranges=0.0.0.0/0 --target-tags ssh --allow=tcp:22 --network=griffin-prod-vpc
@@ -211,6 +221,25 @@ kubectl create -f wp-deployment.yaml
 kubectl create -f wp-service.yaml
 
 echo "${RED}${BOLD}Task 7. ${RESET}""${WHITE}${BOLD}Create a WordPress deployment${RESET}" "${GREEN}${BOLD}Completed${RESET}"
+
+EXTERNAL_IP=""
+while [ -z "$EXTERNAL_IP" ]; do
+  EXTERNAL_IP=$(kubectl get svc wordpress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "Waiting for external IP..."
+  sleep 5
+done
+echo "External IP is: $EXTERNAL_IP"
+
+gcloud monitoring uptime create "Wordpress Uptime Check" \
+  --resource-type="uptime-url" \
+  --resource-labels=host="$EXTERNAL_IP" \
+  --path="/" \
+  --protocol="http" \
+  --port=80 \
+  --period=1 \
+  --timeout=10
+  
+echo "${RED}${BOLD}Task 8. ${RESET}""${WHITE}${BOLD}Enable monitoring${RESET}" "${GREEN}${BOLD}Completed${RESET}"
 
 # Get the IAM policy JSON
 IAM_POLICY_JSON=$(gcloud projects get-iam-policy $DEVSHELL_PROJECT_ID --format=json)

--- a/Develop your Google Cloud Network: Challenge Lab/lab.md
+++ b/Develop your Google Cloud Network: Challenge Lab/lab.md
@@ -10,30 +10,12 @@
 
 ### Run the following Commands in CloudShell
 
-```
-export ZONE=
-```
 ```bash
 
 curl -LO https://raw.githubusercontent.com/Itsabhishek7py/GoogleCloudSkillsboost/refs/heads/main/Develop%20your%20Google%20Cloud%20Network%3A%20Challenge%20Lab/abhishek.sh
 sudo chmod +x abhishek.sh
 ./abhishek.sh
 ```
-
-### Task 8. Enable monitoring
-
-1. Go to [Services and Ingress](https://console.cloud.google.com/kubernetes/discovery)
-2. Copy `endpoint's`(wordpress) `IP address`.
-3. Then go to -> [Uptime Checks](https://console.cloud.google.com/monitoring/uptime) -> `+ CREATE UPTIME CHECK`. 
-4. Fill in the details as provided below : 
-
-* Hostname : `endpoint's IP address` (without http and port number)
-
-* Path : `/`
-
-* Title: `Wordpress Uptime`
-
-5. Leave everything as default. Click `Next` -> `Next` -> `Create`
 
 
 

--- a/Set Up a Google Cloud Network: Challenge Lab/abhishek.sh
+++ b/Set Up a Google Cloud Network: Challenge Lab/abhishek.sh
@@ -166,6 +166,7 @@ gcloud compute instances create $VM_1 \
     --project=$DEVSHELL_PROJECT_ID \
     --zone=$ZONE_1 \
     --subnet=$SUBNET_A \
+    --machine-type=e2-standard-2 \
     --tags=allow-icmp && \
 echo -e "${GREEN}✓ VM 1 created successfully${NC}" || \
 echo -e "${RED}✗ Failed to create VM 1${NC}"
@@ -176,6 +177,7 @@ gcloud compute instances create $VM_2 \
     --project=$DEVSHELL_PROJECT_ID \
     --zone=$ZONE_2 \
     --subnet=$SUBNET_B \
+    --machine-type=e2-standard-2 \
     --tags=allow-icmp && \
 echo -e "${GREEN}✓ VM 2 created successfully${NC}" || \
 echo -e "${RED}✗ Failed to create VM 2${NC}"


### PR DESCRIPTION
## 🟢 Change 1 summary:

https://github.com/Itsabhishek7py/GoogleCloudSkillsboost/pull/26/commits/e339bc514210b0ffc70f7928f821efa3cd2a2e02

Added `--machine-type=e2-standard-2 \` to the following commands.

```bash
gcloud compute instances create $VM_1 \
    --project=$DEVSHELL_PROJECT_ID \
    --zone=$ZONE_1 \
    --subnet=$SUBNET_A \
    --tags=allow-icmp && \
...
gcloud compute instances create $VM_2 \
    --project=$DEVSHELL_PROJECT_ID \
    --zone=$ZONE_2 \
    --subnet=$SUBNET_B \
    --tags=allow-icmp && \
...
```

✅ Test result:     
https://gist.github.com/nov05/2c6f8297888916f082207d3839383622  

👉 Requirements:    
https://www.skills.google/course_templates/641/labs/613012
**Set Up a Google Cloud Network: Challenge Lab**   
**Task 3. Add VMs to your network**  

Create a virtual machine in each subnet, and confirm that the machines can communicate with each other using a protocol that you already set up. Each machine will use network tags that the firewall rules need to allow network traffic.
- Create an instance name `us-test-01` in subnet a name and set the zone to ZONE. 
  Set the Machine type to `e2-standard-2`
- Create an instance name `us-test-02` in subnet b name and set the zone to ZONE. 
  Set the Machine type to `e2-standard-2`

⚠️ Notes:     
If we don’t specify a proper machine type, an older Cloud project may default to `n1-standard-1`, which can sometimes lead to a `ZONE_RESOURCE_POOL_EXHAUSTED` error when that machine type isn’t available in sufficient capacity in the selected zone.

---   

## 🟢 Change 2 summary:

https://github.com/Itsabhishek7py/GoogleCloudSkillsboost/pull/26/commits/877b3e7e5c621b6109e1f83d412ad78b5a68f085

Removed: 

```bash
# gcloud monitoring uptime create lamp-uptime-check \
#   --resource-type="gce-instance" \
#   --resource-labels=project_id=$DEVSHELL_PROJECT_ID,instance_id=$INSTANCE_ID,zone=$ZONE
```

Added: 

```bash
echo "${GREEN_TEXT}${BOLD_TEXT}Fetching External IP...${RESET_FORMAT}"
EXTERNAL_IP="$(gcloud compute instances describe lamp-1-vm --zone=$ZONE --format="get(networkInterfaces[0].accessConfigs[0].natIP)")"
...
gcloud monitoring uptime create "Lamp Uptime Check" \
  --resource-type="uptime-url" \
  --resource-labels=host="$EXTERNAL_IP" \
  --path="/" \
  --protocol="http" \
  --port=80 \
  --period=1 \
  --timeout=10
```

✅ Test result:     
https://gist.github.com/nov05/af6a6df7ae24a8153ba75caaa641a2b1   

👉 Requirements:     
https://www.skills.google/games/7176/labs/44468   
**Cloud Monitoring: Qwik Start**     
**Task 3. Create an uptime check**  
  
3. For Resource Type, select URL.   
4. For Hostname, Use the External IP of VM.   
9. For Title, type Lamp Uptime Check.    

⚠️ Notes:    
It looks like that the lab content has changed.   

---

## 🟢 Change 3 summary:

https://github.com/Itsabhishek7py/GoogleCloudSkillsboost/pull/26/changes/b0975d813cb27b32d62d8bbe9ac9b39c9714c0a0

* Added the following commands to automate Task 8. 

```bash
EXTERNAL_IP=""
while [ -z "$EXTERNAL_IP" ]; do
  EXTERNAL_IP=$(kubectl get svc wordpress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo "Waiting for external IP..."
  sleep 5
done
echo "External IP is: $EXTERNAL_IP"

gcloud monitoring uptime create "Wordpress Uptime Check" \
  --resource-type="uptime-url" \
  --resource-labels=host="$EXTERNAL_IP" \
  --path="/" \
  --protocol="http" \
  --port=80 \
  --period=1 \
  --timeout=10
  
echo "${RED}${BOLD}Task 8. ${RESET}""${WHITE}${BOLD}Enable monitoring${RESET}" "${GREEN}${BOLD}Completed${RESET}"
```

* Changed the following command for `--network-interface=subnet=...,network=...` might indirectly matter in this case.  

```bash
# gcloud compute instances create bastion --network-interface=network=griffin-dev-vpc,subnet=griffin-dev-mgmt  --network-interface=network=griffin-prod-vpc,subnet=griffin-prod-mgmt --tags=ssh --zone=$ZONE
gcloud compute instances create bastion \
  --zone=$ZONE \
  --machine-type=e2-medium \
  --network-interface=subnet=griffin-dev-mgmt,network=griffin-dev-vpc \
  --network-interface=subnet=griffin-prod-mgmt,network=griffin-prod-vpc \
  --tags=ssh
```

* Added the following commands:  

```bash
NC='\033[0m' # No Color
read -p "$(echo -e "${BLUE}ENTER ZONE (e.g., us-central1-a): ${NC}")" ZONE
echo ""
```

✅ Test result:    
https://gist.github.com/nov05/0b1004908bd94ae9ed9591f57db722d1?permalink_comment_id=6140950#gistcomment-6140950  

👉 Requirements:   
https://www.skills.google/games/7176/labs/44469     
**Develop your Google Cloud Network: Challenge Lab**  
**Task 8. Enable monitoring**    
Create an uptime check for your WordPress development site.   

⚠️ Notes:   
Converted the manual steps into a Bash script for Task 8.  
Changed the `lab.md` file accordingly.   

