### PR TITLE
Change python to python3 for URL-decoding

### DIFF
--- a/Cloud Speech API 3 Ways: Challenge Lab.md
+++ b/Cloud Speech API 3 Ways: Challenge Lab.md
@@ -145,7 +145,7 @@ response=$(curl -s -X POST \
 echo "$response" > "$task_4_file"
 
 # URL-decode the sentence
-decoded_sentence=$(python -c "import urllib.parse; print(urllib.parse.unquote('$task_5_sentence'))")
+decoded_sentence=$(python3 -c "import urllib.parse; print(urllib.parse.unquote('$task_5_sentence'))")
 
 # Make the Language Detection API request using curl
 curl -s -X POST \


### PR DESCRIPTION
Lab not working with python must be migrated to python3

Updated the Python command to use python3 for URL-decoding.